### PR TITLE
adds the flatStructure option to the prep renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ const defaultConfig = {
   minify: false,
   concurrency: 4,
   additionalSitemapUrls: [],
+  flatStructure: false,
 }
 ```
 
@@ -57,6 +58,7 @@ const defaultConfig = {
 * `minify` is a boolean or a [html-minifier](https://github.com/kangax/html-minifier) configuration object.
 * `concurrency` controls how many routes are pre-rendered in parallel. (Default: `4`)
 * `additionalSitemapUrls` is a list of URLs to include as well to the generated `sitemap.xml`. (Default: `[]`)
+* `flatStructure` controls if prep should generate index.html files in route named subfolders or `{routeName}.html` files at top level. (Default: `false`)
 
 ## Example `prep.js`
 


### PR DESCRIPTION
This PR adds the `flatStructure` option to prep in order to be able to generate multiple HTML files at the top level of the output directory.

This was a use case we had for a react based MPA with multiple entry points and HTML files being generated that we wanted to run pre-rendering on, and prep was the only solution that fit our needs.